### PR TITLE
Revert "Use official docker buildx action"

### DIFF
--- a/.github/workflows/master-build.yml
+++ b/.github/workflows/master-build.yml
@@ -36,7 +36,7 @@ jobs:
         run: mvn -B package --file pom.xml
       - name: install buildx
         id: buildx
-        uses: docker/setup-buildx-action@v1
+        uses: crazy-max/ghaction-docker-buildx@v3.3.1
         with:
           buildx-version: latest
       - name: Login to Docker Hub


### PR DESCRIPTION
This reverts commit fc46de5cc95e9e4f356601bfb6f9e2a0e9a8fef9 in favour of https://github.com/YNedderhoff/citytweets/pull/39