### PR TITLE
improvements to reduce amount of api calls

### DIFF
--- a/src/main/java/xyz/nedderhoff/citytweets/api/mastodon/api1/AccountsEndpoint.java
+++ b/src/main/java/xyz/nedderhoff/citytweets/api/mastodon/api1/AccountsEndpoint.java
@@ -33,7 +33,7 @@ public class AccountsEndpoint extends MastodonApi1Endpoint {
         super(rt, metricService);
     }
 
-    public Set<String> getFollowers(MastodonAccount mastodonAccount) {
+    public Set<Long> getFollowers(MastodonAccount mastodonAccount) {
         logger.debug("Fetching followers for account {}", mastodonAccount.name());
         final HttpHeaders authedHeaders = getHttpHeadersWithAuth(mastodonAccount);
         final HttpEntity<Account[]> request = new HttpEntity<>(authedHeaders);
@@ -67,7 +67,7 @@ public class AccountsEndpoint extends MastodonApi1Endpoint {
         return Arrays.stream(response.getBody()).map(Account::id).collect(Collectors.toSet());
     }
 
-    public List<Status> getStatuses(String followerId, MastodonAccount mastodonAccount) {
+    public List<Status> getStatuses(Long followerId, MastodonAccount mastodonAccount) {
         logger.debug("Fetching statuses for follower {} of account {}", followerId, mastodonAccount.name());
         final HttpHeaders authedHeaders = getHttpHeadersWithAuth(mastodonAccount);
         final HttpEntity<Account[]> request = new HttpEntity<>(authedHeaders);

--- a/src/main/java/xyz/nedderhoff/citytweets/api/mastodon/api1/StatusEndpoint.java
+++ b/src/main/java/xyz/nedderhoff/citytweets/api/mastodon/api1/StatusEndpoint.java
@@ -30,7 +30,7 @@ public class StatusEndpoint extends MastodonApi1Endpoint {
     }
 
     public Status boost(Status status, MastodonAccount mastodonAccount) throws MastodonException {
-        logger.info("Boosting status {} for {}", status.uri(), mastodonAccount.name());
+        logger.info("Boosting status {} for {}", status.id(), mastodonAccount.name());
         final HttpHeaders authedHeaders = getHttpHeadersWithAuth(mastodonAccount);
         final HttpEntity<Account[]> request = new HttpEntity<>(authedHeaders);
 

--- a/src/main/java/xyz/nedderhoff/citytweets/cache/AbstractFollowerCache.java
+++ b/src/main/java/xyz/nedderhoff/citytweets/cache/AbstractFollowerCache.java
@@ -67,6 +67,10 @@ public abstract class AbstractFollowerCache<
         cache.get(account).add(id);
     }
 
+    public Set<Long> getFollowers(AccountType account) {
+        return new HashSet<>(cache.get(account));
+    }
+
     private void populateCache() {
         final Stopwatch totalTimer = Stopwatch.createStarted();
         accountService.getAccounts().forEach(account -> {

--- a/src/main/java/xyz/nedderhoff/citytweets/cache/AbstractFollowerCache.java
+++ b/src/main/java/xyz/nedderhoff/citytweets/cache/AbstractFollowerCache.java
@@ -18,25 +18,24 @@ import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
 
 public abstract class AbstractFollowerCache<
-        IdType,
         AccountType extends AccountProperties.Account,
         AccountServiceType extends AccountService<AccountType>,
         MetricServiceType extends MetricService,
         ExceptionType extends NonExistingCacheException
-        > implements FollowerCache<IdType, AccountType, AccountServiceType, ExceptionType> {
+        > implements FollowerCache<AccountType, AccountServiceType, ExceptionType> {
 
     private static final int FOLLOWER_UPDATE_RATE = 1000 * 60 * 60 * 24;
     private static final int METRICS_REPORT_RATE = 1000 * 60;
 
     private final AccountServiceType accountService;
-    private final Function<AccountType, Set<IdType>> friendsFetcher;
+    private final Function<AccountType, Set<Long>> friendsFetcher;
     private final MetricServiceType metricService;
-    private final Map<AccountType, Set<IdType>> cache = new ConcurrentHashMap<>();
+    private final Map<AccountType, Set<Long>> cache = new ConcurrentHashMap<>();
     private final Logger logger = getLogger();
 
     public AbstractFollowerCache(
             AccountServiceType accountService,
-            Function<AccountType, Set<IdType>> friendsFetcher,
+            Function<AccountType, Set<Long>> friendsFetcher,
             MetricServiceType metricService) {
         this.accountService = accountService;
         this.friendsFetcher = friendsFetcher;
@@ -58,12 +57,12 @@ public abstract class AbstractFollowerCache<
     }
 
     @Override
-    public boolean contains(IdType id, AccountType account) {
+    public boolean contains(Long id, AccountType account) {
         return cache.get(account).contains(id);
     }
 
     @Override
-    public void add(IdType id, AccountType account) {
+    public void add(Long id, AccountType account) {
         logger.info("Adding friend {} of account {}", id, account.name());
         cache.get(account).add(id);
     }

--- a/src/main/java/xyz/nedderhoff/citytweets/cache/AbstractRepostCache.java
+++ b/src/main/java/xyz/nedderhoff/citytweets/cache/AbstractRepostCache.java
@@ -12,13 +12,12 @@ import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 
 public abstract class AbstractRepostCache<
-        IdType,
         AccountType extends Account,
         AccountServiceType extends AccountService<AccountType>,
         ExceptionType extends NonExistingCacheException
-        > implements RepostCache<IdType, AccountType, AccountServiceType, ExceptionType> {
+        > implements RepostCache<AccountType, AccountServiceType, ExceptionType> {
     protected static final String CACHE_INEXISTENT_EXCEPTION_MESSAGE = "No cache exists for %s account %s";
-    private final Map<AccountType, Set<IdType>> cache = new ConcurrentHashMap<>();
+    private final Map<AccountType, Set<Long>> cache = new ConcurrentHashMap<>();
     private final Logger logger = getLogger();
 
 
@@ -31,7 +30,7 @@ public abstract class AbstractRepostCache<
     }
 
     @Override
-    public boolean contains(IdType id, AccountType account) {
+    public boolean contains(Long id, AccountType account) {
         if (cache.containsKey(account)) {
             return cache.get(account).contains(id);
         } else {
@@ -40,7 +39,7 @@ public abstract class AbstractRepostCache<
     }
 
     @Override
-    public void add(IdType id, AccountType account) {
+    public void add(Long id, AccountType account) {
         logger.info("Adding post {}", id);
 
         cache.computeIfPresent(account, (a, reposts) -> {

--- a/src/main/java/xyz/nedderhoff/citytweets/cache/AbstractRepostCache.java
+++ b/src/main/java/xyz/nedderhoff/citytweets/cache/AbstractRepostCache.java
@@ -33,12 +33,7 @@ public abstract class AbstractRepostCache<
     @Override
     public boolean contains(IdType id, AccountType account) {
         if (cache.containsKey(account)) {
-            // TODO remove log
-            logger.info("Cache contains account {}", account.name());
-            final boolean contains = cache.get(account).contains(id);
-            // TODO remove log
-            logger.info("Cache contains status with id {}: {}", id, contains);
-            return contains;
+            return cache.get(account).contains(id);
         } else {
             throw getException(getExceptionMessage(account));
         }
@@ -53,9 +48,6 @@ public abstract class AbstractRepostCache<
             return reposts;
         });
         cache.computeIfAbsent(account, a -> new HashSet<>(List.of(id)));
-
-        // TODO remove call
-        contains(id, account);
     }
 
     protected abstract ExceptionType getException(String s);

--- a/src/main/java/xyz/nedderhoff/citytweets/cache/ExistenceCheckCache.java
+++ b/src/main/java/xyz/nedderhoff/citytweets/cache/ExistenceCheckCache.java
@@ -5,13 +5,12 @@ import xyz.nedderhoff.citytweets.exception.NonExistingCacheException;
 import xyz.nedderhoff.citytweets.service.AccountService;
 
 public interface ExistenceCheckCache<
-        IdType,
         AccountType extends Account,
         AccountServiceType extends AccountService<AccountType>,
         ExceptionType extends NonExistingCacheException
         > {
 
-    boolean contains(IdType id, AccountType account);
+    boolean contains(Long id, AccountType account);
 
-    void add(IdType id, AccountType account);
+    void add(Long id, AccountType account);
 }

--- a/src/main/java/xyz/nedderhoff/citytweets/cache/FollowerCache.java
+++ b/src/main/java/xyz/nedderhoff/citytweets/cache/FollowerCache.java
@@ -5,9 +5,8 @@ import xyz.nedderhoff.citytweets.exception.NonExistingCacheException;
 import xyz.nedderhoff.citytweets.service.AccountService;
 
 public interface FollowerCache<
-        IdType,
         AccountType extends AccountProperties.Account,
         AccountServiceType extends AccountService<AccountType>,
         ExceptionType extends NonExistingCacheException
-        > extends ExistenceCheckCache<IdType, AccountType, AccountServiceType, ExceptionType> {
+        > extends ExistenceCheckCache<AccountType, AccountServiceType, ExceptionType> {
 }

--- a/src/main/java/xyz/nedderhoff/citytweets/cache/RepostCache.java
+++ b/src/main/java/xyz/nedderhoff/citytweets/cache/RepostCache.java
@@ -5,9 +5,8 @@ import xyz.nedderhoff.citytweets.exception.NonExistingCacheException;
 import xyz.nedderhoff.citytweets.service.AccountService;
 
 public interface RepostCache<
-        IdType,
         AccountType extends AccountProperties.Account,
         AccountServiceType extends AccountService<AccountType>,
         ExceptionType extends NonExistingCacheException
-        > extends ExistenceCheckCache<IdType, AccountType, AccountServiceType, ExceptionType> {
+        > extends ExistenceCheckCache<AccountType, AccountServiceType, ExceptionType> {
 }

--- a/src/main/java/xyz/nedderhoff/citytweets/cache/mastodon/MastodonFollowerCache.java
+++ b/src/main/java/xyz/nedderhoff/citytweets/cache/mastodon/MastodonFollowerCache.java
@@ -16,7 +16,6 @@ import xyz.nedderhoff.citytweets.service.mastodon.MastodonAccountService;
 @Component
 @EnableScheduling
 public class MastodonFollowerCache extends AbstractFollowerCache<
-        String,
         MastodonAccount,
         MastodonAccountService,
         MastodonMetricService,

--- a/src/main/java/xyz/nedderhoff/citytweets/cache/mastodon/RetootCache.java
+++ b/src/main/java/xyz/nedderhoff/citytweets/cache/mastodon/RetootCache.java
@@ -12,7 +12,6 @@ import xyz.nedderhoff.citytweets.service.mastodon.MastodonAccountService;
 @Lazy
 @Component
 public class RetootCache extends AbstractRepostCache<
-        String,
         MastodonAccount,
         MastodonAccountService,
         NonExistingMastodonCacheException

--- a/src/main/java/xyz/nedderhoff/citytweets/cache/twitter/RetweetCache.java
+++ b/src/main/java/xyz/nedderhoff/citytweets/cache/twitter/RetweetCache.java
@@ -12,7 +12,6 @@ import xyz.nedderhoff.citytweets.service.twitter.TwitterAccountService;
 @Lazy
 @Component
 public class RetweetCache extends AbstractRepostCache<
-        Long,
         TwitterAccount,
         TwitterAccountService,
         NonExistingTwitterCacheException

--- a/src/main/java/xyz/nedderhoff/citytweets/cache/twitter/TwitterFollowerCache.java
+++ b/src/main/java/xyz/nedderhoff/citytweets/cache/twitter/TwitterFollowerCache.java
@@ -16,7 +16,6 @@ import xyz.nedderhoff.citytweets.service.twitter.TwitterAccountService;
 @Component
 @EnableScheduling
 public class TwitterFollowerCache extends AbstractFollowerCache<
-        Long,
         TwitterAccount,
         TwitterAccountService,
         TwitterMetricService,

--- a/src/main/java/xyz/nedderhoff/citytweets/domain/mastodon/http/Account.java
+++ b/src/main/java/xyz/nedderhoff/citytweets/domain/mastodon/http/Account.java
@@ -2,10 +2,13 @@ package xyz.nedderhoff.citytweets.domain.mastodon.http;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.deser.std.FromStringDeserializer;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 public record Account(
-        @JsonProperty("id") String id,
+        @JsonDeserialize(using = FromStringDeserializer.class)
+        @JsonProperty("id") Long id,
         @JsonProperty("username") String name,
         @JsonProperty("acct") String webfingerUri
 ) {

--- a/src/main/java/xyz/nedderhoff/citytweets/domain/mastodon/http/Status.java
+++ b/src/main/java/xyz/nedderhoff/citytweets/domain/mastodon/http/Status.java
@@ -9,10 +9,11 @@ public record Status(
         String id,
         String uri,
         String url,
-        String spoiler_text,
         Account account,
         List<Mention> mentions,
-        Reblog reblog
+        Reblog reblog,
+
+        boolean reblogged
 ) {
     public record Mention(
             String id,

--- a/src/main/java/xyz/nedderhoff/citytweets/domain/mastodon/http/Status.java
+++ b/src/main/java/xyz/nedderhoff/citytweets/domain/mastodon/http/Status.java
@@ -1,12 +1,15 @@
 package xyz.nedderhoff.citytweets.domain.mastodon.http;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.deser.std.FromStringDeserializer;
 
 import java.util.List;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 public record Status(
-        String id,
+        @JsonDeserialize(using = FromStringDeserializer.class)
+        Long id,
         String uri,
         String url,
         Account account,
@@ -16,13 +19,15 @@ public record Status(
         boolean reblogged
 ) {
     public record Mention(
-            String id,
+            @JsonDeserialize(using = FromStringDeserializer.class)
+            Long id,
             String username
     ) {
     }
 
     public record Reblog(
-            String id
+            @JsonDeserialize(using = FromStringDeserializer.class)
+            Long id
     ) {
 
     }

--- a/src/main/java/xyz/nedderhoff/citytweets/service/AbstractRepostService.java
+++ b/src/main/java/xyz/nedderhoff/citytweets/service/AbstractRepostService.java
@@ -6,9 +6,8 @@ import xyz.nedderhoff.citytweets.config.AccountProperties.Account;
 import java.util.function.Consumer;
 
 public abstract class AbstractRepostService<
-        IdType,
         AccountType extends Account,
-        RepostCacheType extends RepostCache<IdType, AccountType, AccountServiceType, ?>,
+        RepostCacheType extends RepostCache<AccountType, AccountServiceType, ?>,
         AccountServiceType extends AccountService<AccountType>
         >
         implements RepostService {
@@ -21,7 +20,7 @@ public abstract class AbstractRepostService<
         this.accountService = accountService;
     }
 
-    protected boolean hasBeenSeen(IdType id, AccountType account, Consumer<IdType> hasBeenSeenLogger) {
+    protected boolean hasBeenSeen(Long id, AccountType account, Consumer<Long> hasBeenSeenLogger) {
         final boolean hasBeenSeen = repostCache.contains(id, account);
         if (hasBeenSeen) {
             hasBeenSeenLogger.accept(id);
@@ -39,7 +38,7 @@ public abstract class AbstractRepostService<
         return isAuthorBlocked;
     }
 
-    protected void cache(IdType id, AccountType account) {
+    protected void cache(Long id, AccountType account) {
         repostCache.add(id, account);
     }
 

--- a/src/main/java/xyz/nedderhoff/citytweets/service/mastodon/MastodonBoostService.java
+++ b/src/main/java/xyz/nedderhoff/citytweets/service/mastodon/MastodonBoostService.java
@@ -56,28 +56,44 @@ public class MastodonBoostService extends AbstractRepostService<String, Mastodon
         final boolean mentionsOwnAccount = status.mentions().stream()
                 .anyMatch(mention -> mention.username().equals(account.name()));
         if (mentionsOwnAccount) {
-            logger.warn("Toot {} from user {} mentions own account:\n{}", status.id(), status.account().webfingerUri(), status.spoiler_text());
+            logger.warn(
+                    "Toot {} from user {} mentions own account:{}",
+                    status.id(), status.account().webfingerUri(), status.url()
+            );
         }
         return mentionsOwnAccount;
     }
 
     private boolean shouldRetoot(Status status, MastodonAccount account) {
         final Consumer<String> hasBeenSeenLogger = (id) ->
-                logger.warn("Toot {} from user {} was already reposted:\n{}", id, status.account().webfingerUri(), status.spoiler_text());
+                logger.warn("Toot {} from user {} was already reposted: {}", id, status.account().webfingerUri(), status.url());
         final Consumer<String> authorBlockedLogger = (username) ->
-                logger.warn("Toot {} from user {} can't be reposted as author is blocked:\n{}", status.id(), username, status.spoiler_text());
+                logger.warn("Toot {} from user {} can't be reposted as author is blocked: {}", status.id(), username, status.url());
 
-        return statusMentionsOwnAccount(status, account)
-                && !isFromMe(status, account)
+        return !hasRebloggedStatus(status)
                 && !hasBeenSeen(status.id(), account, hasBeenSeenLogger)
+                && statusMentionsOwnAccount(status, account)
+                && !isFromMe(status, account)
                 && !isAuthorBlocked(status.account().webfingerUri(), account, authorBlockedLogger);
+    }
+
+    private static boolean hasRebloggedStatus(Status status) {
+        final boolean reblogged = status.reblogged();
+
+        if (reblogged) {
+            logger.warn(
+                    "Toot {} from user {} has been reposted already according to Mastodon: {}",
+                    status.id(), status.account().webfingerUri(), status.url()
+            );
+        }
+        return reblogged;
     }
 
 
     protected boolean isFromMe(Status status, MastodonAccount account) {
         final boolean isFromMe = status.account().webfingerUri().equals(account.name() + "@" + account.instance());
         if (isFromMe) {
-            logger.warn("Toot {} from user {} is from me:\n{}", status.id(), status.account().webfingerUri(), status.spoiler_text());
+            logger.warn("Toot {} from user {} is from me: {}", status.id(), status.account().webfingerUri(), status.url());
         }
         return isFromMe;
     }

--- a/src/main/java/xyz/nedderhoff/citytweets/service/mastodon/MastodonBoostService.java
+++ b/src/main/java/xyz/nedderhoff/citytweets/service/mastodon/MastodonBoostService.java
@@ -13,7 +13,7 @@ import xyz.nedderhoff.citytweets.service.AbstractRepostService;
 import java.util.function.Consumer;
 
 @Service
-public class MastodonBoostService extends AbstractRepostService<String, MastodonAccount, RetootCache, MastodonAccountService> {
+public class MastodonBoostService extends AbstractRepostService<MastodonAccount, RetootCache, MastodonAccountService> {
     private static final Logger logger = LoggerFactory.getLogger(MastodonBoostService.class);
     private final AccountsEndpoint accountsEndpoint;
     private final StatusEndpoint statusEndpoint;
@@ -65,7 +65,7 @@ public class MastodonBoostService extends AbstractRepostService<String, Mastodon
     }
 
     private boolean shouldRetoot(Status status, MastodonAccount account) {
-        final Consumer<String> hasBeenSeenLogger = (id) ->
+        final Consumer<Long> hasBeenSeenLogger = (id) ->
                 logger.warn("Toot {} from user {} was already reposted: {}", id, status.account().webfingerUri(), status.url());
         final Consumer<String> authorBlockedLogger = (username) ->
                 logger.warn("Toot {} from user {} can't be reposted as author is blocked: {}", status.id(), username, status.url());

--- a/src/main/java/xyz/nedderhoff/citytweets/service/twitter/TwitterRetweetService.java
+++ b/src/main/java/xyz/nedderhoff/citytweets/service/twitter/TwitterRetweetService.java
@@ -15,7 +15,7 @@ import xyz.nedderhoff.citytweets.service.AbstractRepostService;
 import java.util.function.Consumer;
 
 @Service
-public class TwitterRetweetService extends AbstractRepostService<Long, TwitterAccount, RetweetCache, TwitterAccountService> {
+public class TwitterRetweetService extends AbstractRepostService<TwitterAccount, RetweetCache, TwitterAccountService> {
     private static final Logger logger = LoggerFactory.getLogger(TwitterRetweetService.class);
 
     private final RecentTweetsEndpoint recentTweetsEndpoint;

--- a/src/main/java/xyz/nedderhoff/citytweets/util/serialization/LongFromStringDeserializer.java
+++ b/src/main/java/xyz/nedderhoff/citytweets/util/serialization/LongFromStringDeserializer.java
@@ -1,0 +1,18 @@
+package xyz.nedderhoff.citytweets.util.serialization;
+
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.deser.std.FromStringDeserializer;
+
+import java.io.IOException;
+
+public class LongFromStringDeserializer extends FromStringDeserializer<Long> {
+
+    protected LongFromStringDeserializer(Class<?> vc) {
+        super(vc);
+    }
+
+    @Override
+    protected Long _deserialize(String s, DeserializationContext deserializationContext) throws IOException {
+        return Long.valueOf(s);
+    }
+}


### PR DESCRIPTION
- Get followers from cache instead of API
- Fetch new statuses only upwards from highest known id
- Check for `reblogged` status before even attempting to retoot it